### PR TITLE
Voluntarily crash when fgets returns a NULL value

### DIFF
--- a/lib/base.c
+++ b/lib/base.c
@@ -399,7 +399,12 @@ void printboaln(bool *a, int n) {
 void get_line(char *line, int n) {
     require_not_null(line);
     require("not too small", n >= 8);
-    assert_not_null(fgets(line, n, stdin));
+
+    if(fgets(line, n, stdin) == NULL) {
+        fprintf(stderr, "get_line has failed: fgets() returned NULL!\n");
+        exit(EXIT_FAILURE);
+    }
+
     n = strlen(line);
     if (n >= 1 && (line[n-1] == '\n' || line[n-1] == '\r')) line[n-1] = '\0'; 
     if (n >= 2 && (line[n-2] == '\n' || line[n-2] == '\r')) line[n-2] = '\0'; 
@@ -411,7 +416,12 @@ String s_input(int n) {
     if (n < 8) n = 8;
     char *line = base_malloc(__FILE__, __func__, __LINE__, n);
     *line = '\0';
-    assert_not_null(fgets(line, n, stdin));
+
+    if(fgets(line, n, stdin) == NULL) {
+        fprintf(stderr, "s_input has failed: fgets() returned NULL!\n");
+        exit(EXIT_FAILURE);
+    }
+
     n = strlen(line);
     if (n >= 1 && (line[n-1] == '\n' || line[n-1] == '\r')) line[n-1] = '\0'; 
     if (n >= 2 && (line[n-2] == '\n' || line[n-2] == '\r')) line[n-2] = '\0'; 

--- a/lib/base.c
+++ b/lib/base.c
@@ -399,7 +399,7 @@ void printboaln(bool *a, int n) {
 void get_line(char *line, int n) {
     require_not_null(line);
     require("not too small", n >= 8);
-    fgets(line, n, stdin);
+    assert_not_null(fgets(line, n, stdin));
     n = strlen(line);
     if (n >= 1 && (line[n-1] == '\n' || line[n-1] == '\r')) line[n-1] = '\0'; 
     if (n >= 2 && (line[n-2] == '\n' || line[n-2] == '\r')) line[n-2] = '\0'; 
@@ -411,7 +411,7 @@ String s_input(int n) {
     if (n < 8) n = 8;
     char *line = base_malloc(__FILE__, __func__, __LINE__, n);
     *line = '\0';
-    fgets(line, n, stdin);
+    assert_not_null(fgets(line, n, stdin));
     n = strlen(line);
     if (n >= 1 && (line[n-1] == '\n' || line[n-1] == '\r')) line[n-1] = '\0'; 
     if (n >= 2 && (line[n-2] == '\n' || line[n-2] == '\r')) line[n-2] = '\0'; 


### PR DESCRIPTION
`s_input` and `get_line` don't check the return value of fgets. This can lead to unexpected behavior when stdin in closed (which can be done by the user if they press CTRL+D in their terminal).
This patch simply adds an assertion to both functions to ensure that fgets does not return null.