### PR TITLE
fix: mark base_exit as noreturn

### DIFF
--- a/lib/base.h
+++ b/lib/base.h
@@ -717,7 +717,7 @@ Our own version of exit. Remembers the exit status before calling the ``real'' e
 @param[in] status exit status of the process
 @private
 */
-void base_exit(int status);
+void __attribute__((noreturn)) base_exit(int status);
 
 /**
 Exits the process and returns the given status to the operating system.


### PR DESCRIPTION
### Problem Description

Currently, including `base.h` will overwrite the `exit` function with `base_exit` and the compiler doesn't know how the function behaves and in particular, it doesn't know this function will exit.

Consider this simple program:

```c
#include "base.h"

typedef enum character_category_t {
    CC_ALPHA,
    CC_ALPHANUM,
} CharacterCategory;

char *get_name(CharacterCategory c) {
    switch(c) {
        case CC_ALPHA:
            return "Alpha";
        case CC_ALPHANUM:
            return "Alphanumeric";
        default:
            exit(1);
    }
}

int main() {
    printf("Category: %s\n", get_name(CC_ALPHA));
    return 0;
}
```
In `get_name` we return a name for a `CharacterCategory`. If we receive an invalid category, we want to panic and exit with a non-zero status code.

Compiling this won't work:
```
simple.c: In function 'get_name':
simple.c:17:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
```
The compiler wants us to return something in the default case. But we _know_, that `exit` will stop execution. There's no point in returning anything.

### Solution

GCC exposes the `__attribute__` macro and in particular [`__attribute__((noreturn))`](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-noreturn-function-attribute) to mark a function as noreturn.

_Note:_ In C11, a new header, [`stdnoreturn.h`](https://en.cppreference.com/w/c/language/_Noreturn) was added which simplifies this.

With this fix, the example compiles without any error.

### Further Improvements

These new functions/macros _could_ be added:

* **panic(msg)**: Which would immediately exit with an error. Currently one could use `assert(msg, false)`.
* **unreachable()**: Same as `panic`, but with a default message. This would be useful for switch statements such as the one above.

They only make sense once `base_exit` is marked as noreturn. 